### PR TITLE
Update navbar background color

### DIFF
--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -470,7 +470,8 @@ details p {
 }
 
 .static .navbar {
-    background-color: rgb(0,0,0,0);
+    background-color: rgb(0,0,0, 0.5);
+    backdrop-filter: blur(0.5rem);
     border-bottom: none;
     position: fixed;
     top: 0;


### PR DESCRIPTION
### Description

This PR is related to issue #2, which describes that the sticky navbar does not have a background color, which causes a 

### Before
![sticky header with no background color](https://user-images.githubusercontent.com/55207584/218257456-b56b9091-2254-4e3b-8541-d3ed75ba4318.png)

### After
![sticky header with background color](https://user-images.githubusercontent.com/55207584/218257617-be68049e-7f51-4bef-ab83-0d12d1f39855.png)